### PR TITLE
ci: make tfsec commenter advisory

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -12,6 +12,7 @@
   "language": "en",
   "noConfigSearch": true,
   "words": [
+    "aquasecurity",
     "direnv",
     "Direnv",
     "dangerfile",
@@ -21,7 +22,9 @@
     "megalinter",
     "nanlabs",
     "oxsecurity",
-    "preconfigured"
+    "preconfigured",
+    "tfsec",
+    "Tfsec"
   ],
   "version": "0.2"
 }

--- a/.github/workflows/tf-sec.yml
+++ b/.github/workflows/tf-sec.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Run tfsec
         uses: aquasecurity/tfsec-pr-commenter-action@v1.3.1
+        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tfsec_version: v1.28.14


### PR DESCRIPTION
## Description

Makes the tfsec PR commenter step non-blocking. The action currently fails before running tfsec when it uses the repository-scoped GITHUB_TOKEN to query public aquasecurity release assets, so soft_fail_commenter is not enough to keep maintenance PRs unblocked.

Refs #51

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] YAML parsing: ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/tf-sec.yml

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings