### PR TITLE
ci: allow package author spelling

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,6 +16,7 @@
     "direnv",
     "Direnv",
     "dangerfile",
+    "darioscrivano",
     "envrc",
     "Fswitch",
     "kubeconfig",


### PR DESCRIPTION
## Description

Adds the start-stop EC2 package author handle to the CSpell dictionary so dependency maintenance PRs are not blocked by an existing package metadata value.

Refs #41

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- [x] JSON parsing: ruby -e 'require "json"; JSON.parse(File.read(".cspell.json")); puts "ok .cspell.json"'

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings